### PR TITLE
Catch corner case of a valid Trie sub-branch

### DIFF
--- a/boggled_text.py
+++ b/boggled_text.py
@@ -15,8 +15,8 @@ from nltk.tokenize import word_tokenize
 # stop_words = set(stopwords.words('english'))
 # english_words = [w for w in english_words if w not in stop_words]
 
-english_words = ['apple', 'pickle', 'side', 'kick', 'sick', 'mood', 'cat',
-                 'cats', 'man', 'super', 'antman', 'godzilla', 'dog', 'dot',
+english_words = ['apple', 'pickle', 'side', 'kick', 'sick', 'mood', 'cats',
+                 'cat', 'man', 'super', 'antman', 'godzilla', 'dog', 'dot',
                  'sine', 'cos', 'signal', 'bitcoin', 'cool', 'zapper']
 
 boggle = [
@@ -55,7 +55,9 @@ def gen_trie(word, node):
 
     if word[0] not in node:
         node[word[0]] = {'valid': len(word) == 1, 'next': {}}
-
+    elif len(word) == 1:
+        node[word[0]]['valid'] = True 
+        
     # recursively build trie
     gen_trie(word[1:], node[word[0]])
 


### PR DESCRIPTION
The code only sets isValid on sub-paths longer that the current path which is not always true. This will not work as isValid won't be set for words that are prefix's of the current sub-path.

Before the proposed fix:
If you reverse the sample input to have `cats` first and then the word `cat`, following will be the incorrect output:
Found "cats" directions from (0,0)(c) go  c e d
Found "cats" directions from (0,0)(c) go  c d e

After (proposed fix):
Found "cat" directions from (0,0)(c) go  c e
Found "cats" directions from (0,0)(c) go  c e d